### PR TITLE
authorの表記を統一

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
       name="description"
       content="PLC・モーションソフトの設計、タッチパネルの画面設計、制御盤・配電盤の設計及び制作、制御盤の改造及び更新工事ならお任せください。ファクトリーオートメーションに最適なシステムの設計、開発「有限会社シーエーイー関西」"
     />
-    <meta name="author" content="CAE関西" />
+    <meta name="author" content="シーエーイー関西" />
     <meta
       property="og:title"
       content="有限会社シーエーイー関西 | ファクトリーオートメーションに最適なシステムの設計、開発"


### PR DESCRIPTION
メタタグの表記が「CAE関西」になっていたので「シーエーイー関西」に統一した。